### PR TITLE
Implement mta code standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+outTest/

--- a/check_msid_status.py
+++ b/check_msid_status.py
@@ -15,6 +15,7 @@ import sys
 import re
 import string
 import math
+import traceback
 #
 #--- Define Directory Pathing
 #
@@ -49,8 +50,8 @@ def check_status(msid, val, ldict, vdict):
         try:
             status = check_status_neumeric(msid, val, ldict)
             return status
-        except Exception as e:
-            print(f"Error: {e}")
+        except:
+            traceback.print_exc()
             return 'GREEN'
 #
 #--- the value is letters

--- a/check_msid_status.py
+++ b/check_msid_status.py
@@ -16,21 +16,17 @@ import re
 import string
 import math
 #
-#--- set a directory path
+#--- Define Directory Pathing
 #
-path = '/data/mta4/Script/SOH/house_keeping/dir_list'
-with open(path, 'r') as f:
-    data = [line.strip() for line in f.readlines()]
 
-for ent in data:
-    atemp = re.split(':', ent)
-    var   = atemp[1].strip()
-    line  = atemp[0].strip()
-    exec("%s = %s" %(var, line))
+BIN_DIR = '/data/mta4/Script/SOH'
+HOUSE_KEEPING = '/data/mta4/Script/SOH/house_keeping'
+HTML_DIR = '/data/mta4/www/CSH'
+
 #
 #--- append path to a private folder
 #
-sys.path.append(bin_dir)
+sys.path.append(BIN_DIR)
 
 #-------------------------------------------------------------------------------
 #-- check_status: check status of msid                                        --

--- a/check_msid_status.py
+++ b/check_msid_status.py
@@ -55,8 +55,7 @@ def check_status(msid, val, ldict, vdict):
 #
 #--- the value is letters
 #
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
         if val in ['NaN', 'nan', '']:
             return 'CAUTION'
 
@@ -89,8 +88,7 @@ def check_status_neumeric(msid, val, ldict):
 #
     try:
         limit   = ldict[msid]
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
         return "GREEN"
     
     if (len(limit) == 0) or (limit == ['']):
@@ -113,8 +111,7 @@ def check_status_neumeric(msid, val, ldict):
 
             else:
                 return "WARNING"
-        except Exception as e:
-            print(f"Error: {e}")
+        except:
             return 'GREEN'
 
 #-------------------------------------------------------------------------------

--- a/check_msid_status.py
+++ b/check_msid_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /data/mta4/Script/Python3.8/envs/ska3-shiny/bin/python
+#!/proj/sot/ska3/flight/bin/python
 
 #########################################################################
 #                                                                       #

--- a/check_msid_status.py
+++ b/check_msid_status.py
@@ -49,12 +49,14 @@ def check_status(msid, val, ldict, vdict):
         try:
             status = check_status_neumeric(msid, val, ldict)
             return status
-        except:
+        except Exception as e:
+            print(f"Error: {e}")
             return 'GREEN'
 #
 #--- the value is letters
 #
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         if val in ['NaN', 'nan', '']:
             return 'CAUTION'
 
@@ -87,7 +89,8 @@ def check_status_neumeric(msid, val, ldict):
 #
     try:
         limit   = ldict[msid]
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         return "GREEN"
     
     if (len(limit) == 0) or (limit == ['']):
@@ -110,7 +113,8 @@ def check_status_neumeric(msid, val, ldict):
 
             else:
                 return "WARNING"
-        except:
+        except Exception as e:
+            print(f"Error: {e}")
             return 'GREEN'
 
 #-------------------------------------------------------------------------------

--- a/copy_data_from_occ.py
+++ b/copy_data_from_occ.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /data/mta4/Script/Python3.8/envs/ska3-shiny/bin/python
+#!/proj/sot/ska3/flight/bin/python
 
 #####################################################################################
 #                                                                                   #

--- a/copy_data_from_occ.py
+++ b/copy_data_from_occ.py
@@ -73,7 +73,8 @@ def copy_data_from_occ_part(part):
 #
     try:
         hold = run_extract_blob_data(msid_list, mdict, part, ldict)
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         hold = 0
 
 #-------------------------------------------------------------------------------
@@ -140,7 +141,8 @@ def run_extract_blob_data(msid_list, mdict, part, ldict):
 #--- currently we are outside of comm. if the last blob_<part>.json does not contain
 #--- valid data, update
 #
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         if com_time > 240:
             hold = long_blob_extraction(msid_list, mdict, ldict, stop, part)
 
@@ -228,7 +230,8 @@ def check_blob_state(part):
         for ent in data:
             try:
                 mc   = re.search('AOGBIAS1', str(ent))
-            except:
+            except Exception as e:
+                print(f"Error: {e}")
                 continue
 
             if mc is not None:
@@ -264,7 +267,8 @@ def check_blob_state(part):
                     break
             else:
                 run = 1
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         run = 1
 
     return run
@@ -291,7 +295,8 @@ def find_last_upate(tfile, tspan=10800):
     try:
         btime = time.strftime("%Y:%j:%H:%M:%S", time.gmtime(os.path.getmtime(tfile)))
         btime = Chandra.Time.DateTime(btime).secs
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         btime = 0
 
     tdiff = ctime - btime
@@ -331,7 +336,8 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
         ctime = str((list(out['data'][0]['times']))[-1])
         ctime = Chandra.Time.DateTime(ctime).date
         ctime = ctime.replace(':', '')
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         ###ctime = time.strftime("%Y%j%H%M%S", time.gmtime())
         return 'stop'
 
@@ -365,7 +371,8 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
 #
         try:
             mdata = maude.get_msids(msid_short, start, stop)
-        except:
+        except Exception as e:
+            print(f"Error: {e}")
             continue
 #
 #--- now extract data and put into json data format
@@ -374,11 +381,13 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
             try:
                 msid = str(mdata['data'][nk]['msid']).upper()
 
-            except:
+            except Exception as e:
+                print(f"Error: {e}")
                 continue
             try:
                 val  = str((list(mdata['data'][nk]['values']))[-1])
-            except:
+            except Exception as e:
+                print(f"Error: {e}")
                 val = 'NaN'
 #
 #--- unit conversion for a few special cases
@@ -418,7 +427,8 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
             for name in ['1STAT7ST', '1STAT6ST', '1STAT5ST', '1STAT4ST',\
                          '1STAT3ST', '1STAT2ST', '1STAT1ST', '1STAT0ST']:
                 val = val + covert_to_tf(vdict[name])
-        except:
+        except Exception as e:
+            print(f"Error: {e}")
             val  = 'NaN'
         mlist.append(msid)
         vdict[msid] = val
@@ -433,14 +443,16 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
         val = '"' + val + '"'
         try:
             index  = mdict[msid]
-        except:
+        except Exception as e:
+            print(f"Error: {e}")
             index  = str(findx)
             findx -= 1
 
         try:
             sval = val.replace('\"', '')
             status = cms.check_status(msid, sval, ldict, vdict)
-        except:
+        except Exception as e:
+            print(f"Error: {e}")
             status ='GREEN'
 
         out = '{"msid":"' + msid + '",'
@@ -576,10 +588,12 @@ def read_limit_table():
         for val in atemp[1:]:
             try:
                 val = float(val)
-            except:
+            except Exception as e:
+                print(f"Error: {e}")
                 try:
                     val = val.replace("\'", '')
-                except:
+                except Exception as e:
+                    print(f"Error: {e}")
                     pass
             olist.append(val)
         ldict[atemp[0]] = olist
@@ -678,7 +692,8 @@ if __name__ == '__main__':
     try:
         part = sys.argv[1]
         part.strip()
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         print(" USAGE: copy_data_from_occ_part.py <part>")
         exit(1)
 
@@ -692,13 +707,15 @@ if __name__ == '__main__':
             exit(1)
         else:
             write_run_file('1', part)
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         write_run_file('0', part)
         exit(1)
 
     try:
         copy_data_from_occ_part(part)
-    except:
+    except Exception as e:
+        print(f"Error: {e}")
         pass
 
     write_run_file('0', part)

--- a/copy_data_from_occ.py
+++ b/copy_data_from_occ.py
@@ -20,19 +20,18 @@ import Chandra.Time
 import maude
 import json
 import random
-path = '/data/mta4/Script/SOH/house_keeping/dir_list'
-with open(path, 'r') as f:
-    data = [line.strip() for line in f.readlines()]
 
-for ent in data:
-    atemp = re.split(':', ent)
-    var   = atemp[1].strip()
-    line  = atemp[0].strip()
-    exec("%s = %s" %(var, line))
+#
+#--- Define Directory Pathing
+#
+
+BIN_DIR = '/data/mta4/Script/SOH'
+HOUSE_KEEPING = '/data/mta4/Script/SOH/house_keeping'
+HTML_DIR = '/data/mta4/www/CSH'
 #
 #--- append path to a private folder
 #
-sys.path.append(bin_dir)
+sys.path.append(BIN_DIR)
 
 import check_msid_status    as cms
 #
@@ -59,12 +58,12 @@ def copy_data_from_occ_part(part):
 #
 #--- read msid list
 #
-    ifile     = house_keeping + 'Inst_part/msid_list_' + part
+    ifile = f"{HOUSE_KEEPING}/Inst_part/msid_list_{part}"
     msid_list = read_data_file(ifile)
 #
 #--- msid <--> id dict
 #
-    ifile     = house_keeping + 'Inst_part/msid_id_list_' + part
+    ifile = f"{HOUSE_KEEPING}/Inst_part/msid_id_list_{part}"
     data      = read_data_file(ifile)
 
     mdict     = {}
@@ -208,7 +207,7 @@ def write_run_file(chk, part):
     output: <house_keeping>/running_<part> --- udated file
     """
     out   = chk + '\n'
-    ofile = house_keeping + 'running_' + part
+    ofile = f"{HOUSE_KEEPING}/running_{part}"
 
     with open(ofile, 'w') as fo:
         fo.write(out)
@@ -228,7 +227,7 @@ def check_blob_state(part):
     """
     run = 0
     try:
-        bfile = html_dir + 'blob_' + part + '.json'
+        bfile = f"{HTML_DIR}/blob_{part}.json"
         data  = read_data_file(bfile)
     
         chk   = 0
@@ -254,7 +253,7 @@ def check_blob_state(part):
 #--- even if the msid has a valid value, if the real msid data are not updated more than 3 hrs
 #--- update blob_<part>.json, just in a case, the data was not updated for some unknown reasons.
 #
-                        tfile = house_keeping + part + '_last_check'
+                        tfile = f"{HOUSE_KEEPING}/{part}_last_check"
                         if find_last_upate(tfile) == 1:
                             stday = time.strftime("%Y:%j:%H:%M:%S", time.gmtime())
                             update_last_blob_check(part, stday)
@@ -471,7 +470,7 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
 
     line = line + ']'
 
-    out  = html_dir + 'blob_' + part + '.json'
+    out = f"{HTML_DIR}/blob_{part}.json"
     with open(out, 'w') as fo:
         fo.write(line)
 
@@ -574,7 +573,7 @@ def read_limit_table():
     input:  none but read from <house_keeping>/limit_table
     output: ldict   --- dictionary of msid <---> limits
     """
-    ifile = house_keeping + 'limit_table'
+    ifile = f"{HOUSE_KEEPING}/limit_table"
     out   = read_data_file(ifile)
     ldict = {}
     for line in out:
@@ -604,7 +603,7 @@ def update_lastdcheck_entry(part):
     output: data file with the updated dummy msid entry line
     """
 
-    bfile = html_dir + 'blob_' + part + '.json'
+    bfile = f"{HTML_DIR}/blob_{part}.json"
     data  = read_data_file(bfile)
 
     mc    = re.search('LASTDCHECK', data[-3])
@@ -632,7 +631,7 @@ def update_last_blob_check(part, stday):
     output: <house_keeping>/<part>_last_check
     """
 
-    tfile = house_keeping + part + '_last_check'
+    tfile = f"{HOUSE_KEEPING}/{part}_last_check"
     cmd = 'rm -rf ' + tfile
     os.system(cmd)
     cmd = 'echo ' + str(stday) + '> ' + tfile
@@ -643,7 +642,7 @@ def update_last_blob_check(part, stday):
 #-------------------------------------------------------------------------------
 
 def chk_time_to_comm():
-    ifile    = house_keeping + 'stime_to_comm'
+    ifile = f"{HOUSE_KEEPING}/stime_to_comm"
     out      = read_data_file(ifile)
     com_time = float(out[0])
 
@@ -655,7 +654,7 @@ def chk_time_to_comm():
 
 def read_nfile():
 
-    ifile = house_keeping + '.netrc'
+    ifile = f"{HOUSE_KEEPING}/.netrc"
     data  = read_data_file(ifile)
     for ent in data:
         atemp = re.split('\s+', ent)
@@ -692,7 +691,7 @@ if __name__ == '__main__':
 #
 #--- check whether a blob extraction is currently running_<part>; if so, stop
 #
-    ifile   = house_keeping + 'running_' + part
+    ifile = f"{HOUSE_KEEPING}/running_{part}"
     try:
         running = read_data_file(ifile)
         if running[0] == '1':

--- a/copy_data_from_occ.py
+++ b/copy_data_from_occ.py
@@ -588,8 +588,7 @@ def read_limit_table():
         for val in atemp[1:]:
             try:
                 val = float(val)
-            except Exception as e:
-                print(f"Error: {e}")
+            except:
                 try:
                     val = val.replace("\'", '')
                 except Exception as e:

--- a/copy_data_from_occ.py
+++ b/copy_data_from_occ.py
@@ -19,6 +19,7 @@ import time
 import Chandra.Time
 import maude
 import json
+import traceback
 
 #
 #--- Define Directory Pathing
@@ -73,8 +74,8 @@ def copy_data_from_occ_part(part):
 #
     try:
         hold = run_extract_blob_data(msid_list, mdict, part, ldict)
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
+        traceback.print_exc()
         hold = 0
 
 #-------------------------------------------------------------------------------
@@ -141,8 +142,8 @@ def run_extract_blob_data(msid_list, mdict, part, ldict):
 #--- currently we are outside of comm. if the last blob_<part>.json does not contain
 #--- valid data, update
 #
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
+        traceback.print_exc()
         if com_time > 240:
             hold = long_blob_extraction(msid_list, mdict, ldict, stop, part)
 
@@ -230,8 +231,8 @@ def check_blob_state(part):
         for ent in data:
             try:
                 mc   = re.search('AOGBIAS1', str(ent))
-            except Exception as e:
-                print(f"Error: {e}")
+            except:
+                traceback.print_exc()
                 continue
 
             if mc is not None:
@@ -267,8 +268,8 @@ def check_blob_state(part):
                     break
             else:
                 run = 1
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
+        traceback.print_exc()
         run = 1
 
     return run
@@ -295,8 +296,8 @@ def find_last_upate(tfile, tspan=10800):
     try:
         btime = time.strftime("%Y:%j:%H:%M:%S", time.gmtime(os.path.getmtime(tfile)))
         btime = Chandra.Time.DateTime(btime).secs
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
+        traceback.print_exc()
         btime = 0
 
     tdiff = ctime - btime
@@ -336,8 +337,8 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
         ctime = str((list(out['data'][0]['times']))[-1])
         ctime = Chandra.Time.DateTime(ctime).date
         ctime = ctime.replace(':', '')
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
+        traceback.print_exc()
         ###ctime = time.strftime("%Y%j%H%M%S", time.gmtime())
         return 'stop'
 
@@ -371,8 +372,8 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
 #
         try:
             mdata = maude.get_msids(msid_short, start, stop)
-        except Exception as e:
-            print(f"Error: {e}")
+        except:
+            traceback.print_exc()
             continue
 #
 #--- now extract data and put into json data format
@@ -381,13 +382,13 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
             try:
                 msid = str(mdata['data'][nk]['msid']).upper()
 
-            except Exception as e:
-                print(f"Error: {e}")
+            except:
+                traceback.print_exc()
                 continue
             try:
                 val  = str((list(mdata['data'][nk]['values']))[-1])
-            except Exception as e:
-                print(f"Error: {e}")
+            except:
+                traceback.print_exc()
                 val = 'NaN'
 #
 #--- unit conversion for a few special cases
@@ -427,8 +428,8 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
             for name in ['1STAT7ST', '1STAT6ST', '1STAT5ST', '1STAT4ST',\
                          '1STAT3ST', '1STAT2ST', '1STAT1ST', '1STAT0ST']:
                 val = val + covert_to_tf(vdict[name])
-        except Exception as e:
-            print(f"Error: {e}")
+        except:
+            traceback.print_exc()
             val  = 'NaN'
         mlist.append(msid)
         vdict[msid] = val
@@ -443,16 +444,16 @@ def extract_blob_data(msid_list, mdict, ldict, start, stop, part):
         val = '"' + val + '"'
         try:
             index  = mdict[msid]
-        except Exception as e:
-            print(f"Error: {e}")
+        except:
+            traceback.print_exc()
             index  = str(findx)
             findx -= 1
 
         try:
             sval = val.replace('\"', '')
             status = cms.check_status(msid, sval, ldict, vdict)
-        except Exception as e:
-            print(f"Error: {e}")
+        except:
+            traceback.print_exc()
             status ='GREEN'
 
         out = '{"msid":"' + msid + '",'
@@ -591,8 +592,8 @@ def read_limit_table():
             except:
                 try:
                     val = val.replace("\'", '')
-                except Exception as e:
-                    print(f"Error: {e}")
+                except:
+                    traceback.print_exc()
                     pass
             olist.append(val)
         ldict[atemp[0]] = olist
@@ -691,8 +692,8 @@ if __name__ == '__main__':
     try:
         part = sys.argv[1]
         part.strip()
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
+        traceback.print_exc()
         print(" USAGE: copy_data_from_occ_part.py <part>")
         exit(1)
 
@@ -706,15 +707,15 @@ if __name__ == '__main__':
             exit(1)
         else:
             write_run_file('1', part)
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
+        traceback.print_exc()
         write_run_file('0', part)
         exit(1)
 
     try:
         copy_data_from_occ_part(part)
-    except Exception as e:
-        print(f"Error: {e}")
+    except:
+        traceback.print_exc()
         pass
 
     write_run_file('0', part)

--- a/copy_data_from_occ.py
+++ b/copy_data_from_occ.py
@@ -19,7 +19,6 @@ import time
 import Chandra.Time
 import maude
 import json
-import random
 
 #
 #--- Define Directory Pathing
@@ -34,11 +33,6 @@ HTML_DIR = '/data/mta4/www/CSH'
 sys.path.append(BIN_DIR)
 
 import check_msid_status    as cms
-#
-#--- set a temporary file name
-#
-rtail  = int(time.time()*random.random())
-zspace = '/tmp/zspace' + str(rtail)
 
 #-------------------------------------------------------------------------------
 #-- copy_data_from_occ_part: run loop to extract blob for a specific part from occ using maude

--- a/test/test_copy_data_from_occ.py
+++ b/test/test_copy_data_from_occ.py
@@ -1,0 +1,31 @@
+#!/proj/sot/ska3/flight/bin/python
+
+import sys, os
+
+#Path altering to import script which is undergoing testing
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+PARENT_DIR = os.path.dirname(TEST_DIR)
+OUT_DIR = f"{TEST_DIR}/outTest"
+sys.path.insert(0,PARENT_DIR)
+
+new_dir_list = [OUT_DIR, f"{OUT_DIR}/house_keeping", f"{OUT_DIR}/Web"]
+for dir in new_dir_list:
+	os.system(f"mkdir -p {dir}")
+
+import copy_data_from_occ as cdfo
+import check_msid_status as cms
+
+mod_group = [cdfo,cms]
+#Permute across the imported modules to change pathing variables
+for mod in mod_group:
+	if hasattr(mod,'BIN_DIR'):
+		mod.BIN_DIR = f"{PARENT_DIR}"
+	#cdfo uses several file lists stored in house_keeping. Consult/copy from git repo.
+	if hasattr(mod,'HOUSE_KEEPING'):
+		mod.HOUSE_KEEPING = f"{OUT_DIR}/house_keeping"
+	if hasattr(mod,'HTML_DIR'):
+		mod.HTML_DIR = f"{OUT_DIR}/Web"
+	
+part_list = ['snap']
+for part in part_list:
+    cdfo.copy_data_from_occ_part(part)

--- a/test/test_copy_data_from_occ.py
+++ b/test/test_copy_data_from_occ.py
@@ -1,23 +1,43 @@
 #!/proj/sot/ska3/flight/bin/python
 
 import sys, os
+import getpass
 
 #Path altering to import script which is undergoing testing
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 PARENT_DIR = os.path.dirname(TEST_DIR)
 OUT_DIR = f"{TEST_DIR}/outTest"
 sys.path.insert(0,PARENT_DIR)
+LIVE_SCRIPT_DIR = "/data/mta4/Script/SOH"
+LIVE_WEB_DIR = "/data/mta4/www/CSH"
 
-new_dir_list = [OUT_DIR, f"{OUT_DIR}/house_keeping", f"{OUT_DIR}/Web"]
-for dir in new_dir_list:
+
+PART_LIST = ['snap']
+
+#NEW_DIR_LIST = [OUT_DIR, f"{OUT_DIR}/house_keeping", f"{OUT_DIR}/Web"]
+NEW_DIR_LIST = [OUT_DIR, f"{OUT_DIR}/Web"]
+for dir in NEW_DIR_LIST:
 	os.system(f"mkdir -p {dir}")
+
+#Extra house_keeping setup files
+#require MSID lists from git housekeeping
+os.system(f"cp -r {PARENT_DIR}/house_keeping {OUT_DIR}")
+os.system(f"ln -sf /home/{getpass.getuser()}/.netrc {OUT_DIR}/house_keeping/.netrc")
+os.system(f"ln -sf {LIVE_SCRIPT_DIR}/house_keeping/stime_to_comm {OUT_DIR}/house_keeping/")
+
+#Extra Web setup
+for part in PART_LIST:
+    if not os.path.isfile(f"{OUT_DIR}/Web/blob_{part}.json"):
+    	os.system(f"cp {LIVE_WEB_DIR}/blob_{part}.json {OUT_DIR}/Web/")
+
+
 
 import copy_data_from_occ as cdfo
 import check_msid_status as cms
 
-mod_group = [cdfo,cms]
+MOD_GROUP = [cdfo,cms]
 #Permute across the imported modules to change pathing variables
-for mod in mod_group:
+for mod in MOD_GROUP:
 	if hasattr(mod,'BIN_DIR'):
 		mod.BIN_DIR = f"{PARENT_DIR}"
 	#cdfo uses several file lists stored in house_keeping. Consult/copy from git repo.
@@ -26,6 +46,5 @@ for mod in mod_group:
 	if hasattr(mod,'HTML_DIR'):
 		mod.HTML_DIR = f"{OUT_DIR}/Web"
 	
-part_list = ['snap']
-for part in part_list:
+for part in PART_LIST:
     cdfo.copy_data_from_occ_part(part)

--- a/test/test_recent_pull.py
+++ b/test/test_recent_pull.py
@@ -1,0 +1,84 @@
+#!/proj/sot/ska3/flight/bin/python
+
+"""
+This testing script tests specific subfunctions of the 
+copy_data_from_occ python script to check json formatting and
+data of a blob_<part>.json file.
+
+Circumvents script auto-failure to fetch data if not in comm, and
+instead pulls data values which match most recently.
+"""
+
+import sys, os
+import getpass
+import time
+import Chandra.Time
+import re
+
+#Path altering to import script which is undergoing testing
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+PARENT_DIR = os.path.dirname(TEST_DIR)
+OUT_DIR = f"{TEST_DIR}/outTest"
+sys.path.insert(0,PARENT_DIR)
+LIVE_SCRIPT_DIR = "/data/mta4/Script/SOH"
+LIVE_WEB_DIR = "/data/mta4/www/CSH"
+
+
+PART_LIST = ['snap']
+#Subject to change as necessary
+HOUR_PREV = 5
+
+NEW_DIR_LIST = [OUT_DIR, f"{OUT_DIR}/Web"]
+for dir in NEW_DIR_LIST:
+	os.system(f"mkdir -p {dir}")
+
+#Extra house_keeping setup files
+#require MSID lists from git housekeeping
+#but we are testing changes to that data pull, so leave this cmd up to user discretion
+#for changing the lists.
+#os.system(f"cp -r {PARENT_DIR}/house_keeping {OUT_DIR}")
+
+os.system(f"ln -sf /home/{getpass.getuser()}/.netrc {OUT_DIR}/house_keeping/.netrc")
+os.system(f"ln -sf {LIVE_SCRIPT_DIR}/house_keeping/stime_to_comm {OUT_DIR}/house_keeping/")
+
+import copy_data_from_occ as cdfo
+import check_msid_status as cms
+
+MOD_GROUP = [cdfo,cms]
+#Permute across the imported modules to change pathing variables
+for mod in MOD_GROUP:
+	if hasattr(mod,'BIN_DIR'):
+		mod.BIN_DIR = f"{PARENT_DIR}"
+	#cdfo uses several file lists stored in house_keeping. Consult/copy from git repo.
+	if hasattr(mod,'HOUSE_KEEPING'):
+		mod.HOUSE_KEEPING = f"{OUT_DIR}/house_keeping"
+	if hasattr(mod,'HTML_DIR'):
+		mod.HTML_DIR = f"{OUT_DIR}/Web"
+
+stday = time.strftime("%Y:%j:%H:%M:%S", time.gmtime())
+stop  = Chandra.Time.DateTime(stday).secs
+#Define start time as a larger data fetch
+start = stop - 60 *(60* HOUR_PREV)
+
+for part in PART_LIST:
+#
+#--- read msid list
+#
+    ifile = f"{cdfo.HOUSE_KEEPING}/Inst_part/msid_list_{part}"
+    msid_list = cdfo.read_data_file(ifile)
+#
+#--- msid <--> id dict
+#
+    ifile = f"{cdfo.HOUSE_KEEPING}/Inst_part/msid_id_list_{part}"
+    data      = cdfo.read_data_file(ifile)
+
+    mdict     = {}
+    for ent in data:
+        atemp  = re.split(':', ent)
+        mdict[atemp[0]] = atemp[1]
+#
+#--- read limit table
+#
+        ldict = cdfo.read_limit_table()
+#
+    cdfo.extract_blob_data(msid_list, mdict, ldict, start, stop, part)


### PR DESCRIPTION
This PR address Issues #8 and #10 by updating the copy_data_from_occ.py script to current MTA coding standards. This means altering the pathing setup for python version, ska libraries, and directories to adjustable global variables. This PR also includes two testing scripts to test the functionality of this copy_data_from_occ.py script. The decision to leave out the typical lock files as the current setup makes use of a demonized shell script to constantly run this copy_data_from_occ.py script to fetch the relevant comm data. 