### PR TITLE
Ctest xml format

### DIFF
--- a/CSH/soh.html
+++ b/CSH/soh.html
@@ -86,7 +86,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_ccdm1.html
+++ b/CSH/soh_ccdm1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_ccdm2.html
+++ b/CSH/soh_ccdm2.html
@@ -80,7 +80,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_ccdm3.html
+++ b/CSH/soh_ccdm3.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_ccdm4.html
+++ b/CSH/soh_ccdm4.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_eps1.html
+++ b/CSH/soh_eps1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_eps2.html
+++ b/CSH/soh_eps2.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_load1.html
+++ b/CSH/soh_load1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_mech1.html
+++ b/CSH/soh_mech1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_pcad1.html
+++ b/CSH/soh_pcad1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_pcad2.html
+++ b/CSH/soh_pcad2.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_pcad3.html
+++ b/CSH/soh_pcad3.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_pcad4.html
+++ b/CSH/soh_pcad4.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_pcad5.html
+++ b/CSH/soh_pcad5.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_prop1.html
+++ b/CSH/soh_prop1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_sc_config1.html
+++ b/CSH/soh_sc_config1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_smode1.html
+++ b/CSH/soh_smode1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_smode2.html
+++ b/CSH/soh_smode2.html
@@ -82,7 +82,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_smode3.html
+++ b/CSH/soh_smode3.html
@@ -82,7 +82,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_smode4.html
+++ b/CSH/soh_smode4.html
@@ -82,7 +82,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_smode5.html
+++ b/CSH/soh_smode5.html
@@ -82,7 +82,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_smode6.html
+++ b/CSH/soh_smode6.html
@@ -82,7 +82,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_snap.html
+++ b/CSH/soh_snap.html
@@ -88,7 +88,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_snap_tab.html
+++ b/CSH/soh_snap_tab.html
@@ -88,7 +88,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_test.html
+++ b/CSH/soh_test.html
@@ -88,7 +88,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_thermal1.html
+++ b/CSH/soh_thermal1.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_thermal2.html
+++ b/CSH/soh_thermal2.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/CSH/soh_thermal3.html
+++ b/CSH/soh_thermal3.html
@@ -81,7 +81,7 @@
 
         setInterval(function() {
             startTime();
-            loadFile('./ctest');
+            loadFile('./ctest.xml');
         }, 500);
 
         function loadFile(filePath) {

--- a/README
+++ b/README
@@ -58,7 +58,7 @@ next_comm_check.py
 ------------------
 create a display time span till the next comm
 input: none
-output: <web_dir>/ctest
+output: <web_dir>/ctest.xml
 
 soh_snap_script.sh
 ------------------

--- a/next_comm_check.py
+++ b/next_comm_check.py
@@ -59,8 +59,8 @@ def find_next_comm():
         else:
             pstop = stop
 
-    with open('/data/mta4/www/CSH/ctest', 'w') as fo:
-        fo.write(ltime + '\n')
+    with open('/data/mta4/www/CSH/ctest.xml', 'w') as fo:
+        fo.write(f"<ncomm>\n{ltime}\n</ncomm>\n")
     
 #-------------------------------------------------------------------
 #-------------------------------------------------------------------

--- a/next_comm_check.py
+++ b/next_comm_check.py
@@ -29,7 +29,7 @@ def find_next_comm():
     """
     create a display time span till the next comm
     input:  nont, but read from /data/mta4/www/CSH/comm_list.html
-    output: /data/mta4/www/CSH/ctest
+    output: /data/mta4/www/CSH/ctest.xml
     """
     out = time.strftime('%Y:%j:%H:%M:%S', time.gmtime())
     ctime = Chandra.Time.DateTime(out).secs

--- a/time_stamp.py
+++ b/time_stamp.py
@@ -10,5 +10,5 @@ import time
 import Chandra.Time
 
 out = time.strftime('Current Time: %Y:%j:%H:%M Z', time.gmtime()) + '\n'
-with open('/data/mta4/www/CSH/ctest', 'w') as fo:
+with open('/data/mta4/www/CSH/ctest.xml', 'w') as fo:
     fo.write(out)

--- a/time_stamp.py
+++ b/time_stamp.py
@@ -9,6 +9,6 @@ import math
 import time
 import Chandra.Time
 
-out = time.strftime('Current Time: %Y:%j:%H:%M Z', time.gmtime()) + '\n'
+out = f"<ncomm>\n{time.strftime('Current Time: %Y:%j:%H:%M Z', time.gmtime())}\n</ncomm>\n"
 with open('/data/mta4/www/CSH/ctest.xml', 'w') as fo:
     fo.write(out)


### PR DESCRIPTION
The time till the next comm pass is stored in a simple text file called ctest located in the CSH web directory. However, the text file is read with a XML parser but is not formatted as an xml file. While the parser is able to read this file, it send and error message to the client about the incorrect formatting whenever it cannot interpret the file correctly. This results in spam messages popping up every second on in the web client which drowns out other more relevant error messages.

As such, the maude CSH pages have been changed to read the ctest.xml file and the next_comm_check.py and time_stamp.py scripts now generate this file with a properly formatted `<ncomm>` tag.